### PR TITLE
Add an ssh-keyscan step in CI to preload the sftp-qa.planx-pla.net ho…

### DIFF
--- a/.github/workflows/shared_integration_tests.yaml
+++ b/.github/workflows/shared_integration_tests.yaml
@@ -78,7 +78,7 @@ jobs:
           CI_TEST_RAS_2_PASSWORD: ${{ secrets.CI_TEST_RAS_2_PASSWORD }}
           CLOUD_AUTO_BRANCH: ${{ inputs.CLOUD_AUTO_BRANCH }}
           SLACK_CHANNEL: ${{ secrets.CI_SLACK_CHANNEL_ID }}
-          SFTP_QA_HOSTNAME: "http://sftp-qa.planx-pla.net"
+          SFTP_QA_HOSTNAME: "sftp-qa.planx-pla.net"
 
 
         steps:

--- a/.github/workflows/shared_integration_tests.yaml
+++ b/.github/workflows/shared_integration_tests.yaml
@@ -78,6 +78,8 @@ jobs:
           CI_TEST_RAS_2_PASSWORD: ${{ secrets.CI_TEST_RAS_2_PASSWORD }}
           CLOUD_AUTO_BRANCH: ${{ inputs.CLOUD_AUTO_BRANCH }}
           SLACK_CHANNEL: ${{ secrets.CI_SLACK_CHANNEL_ID }}
+          SFTP_QA_HOSTNAME: "http://sftp-qa.planx-pla.net"
+
 
         steps:
           # Ensure the PR is run under the same org as an Internal PR
@@ -174,6 +176,14 @@ jobs:
             run: |
               commit_time=$(gh api repos/$REPO_FN/commits/$COMMIT_SHA | jq -r '.commit.committer.date')
               echo "COMMIT_TIME=$commit_time" >> $GITHUB_ENV
+
+          # Workaround for Paramiko RejectPolicy: pre-load the SFTP host key to avoid connection failure during dbGaP user sync
+          # Without this, Paramiko will reject the host since known_hosts is empty in CI
+          - name: Add SFTP host key to known_hosts
+            if: ${{ env.SKIP_TESTS != 'true' }}
+            run: |
+              mkdir -p ~/.ssh
+              ssh-keyscan -p 22 $SFTP_QA_HOSTNAME >> ~/.ssh/known_hosts
 
           # TODO: Rely on a database in AWS to make this faster
           # Select an unlocked environment


### PR DESCRIPTION
…st key

into known_hosts. This supports the updated Paramiko SSH config that now rejects unknown host keys (RejectPolicy), and fixes failing dbGaP-related integration tests caused by the missing key. The hostname is passed via an env variable for maintainability.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
