### PR TITLE
Fix: Broken guppy_test due to an f-string error 

### DIFF
--- a/gen3-integration-tests/utils/gen3_admin_tasks.py
+++ b/gen3-integration-tests/utils/gen3_admin_tasks.py
@@ -734,10 +734,11 @@ def mutate_manifest_for_guppy_test(
         else:
             cmd_list = [
                 f"kubectl -n {test_env_namespace} get cm etl-mapping -o jsonpath='{{.data.etlMapping\\.yaml}}' > etlMapping.yaml",
-                'sed -i "s/"index":"[^"]*_subject_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep subject)"/" original_guppy_config.yaml',
-                'sed -i "s/"index":"[^"]*_file_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep file)"/" original_guppy_config.yaml',
+                'sed -i \'s/"index":"[^"]*_subject_alias"/"index":"\'$(yq \'.mappings[].name\' etlMapping.yaml | grep subject)\'"/\' original_guppy_config.yaml',
+                'sed -i \'s/"index":"[^"]*_file_alias"/"index":"\'$(yq \'.mappings[].name\' etlMapping.yaml | grep file)\'"/\' original_guppy_config.yaml',
             ]
             for cmd in cmd_list:
+                logger.info(f"Executing command: {cmd}")
                 cmd_result = subprocess.run(
                     cmd,
                     stdout=subprocess.PIPE,

--- a/gen3-integration-tests/utils/gen3_admin_tasks.py
+++ b/gen3-integration-tests/utils/gen3_admin_tasks.py
@@ -733,9 +733,7 @@ def mutate_manifest_for_guppy_test(
         # If indexname is not set to jenkins set guppy config to manifest based changes
         else:
             cmd_list = [
-                "kubectl -n "
-                + test_env_namespace
-                + " get cm etl-mapping -o jsonpath='{.data.etlMapping\\.yaml}' > etlMapping.yaml",
+                f"kubectl -n {test_env_namespace} get cm etl-mapping -o jsonpath='{{.data.etlMapping\\.yaml}}' > etlMapping.yaml",
                 'sed -i "s/"index":"[^"]*_subject_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep subject)"/" original_guppy_config.yaml',
                 'sed -i "s/"index":"[^"]*_file_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep file)"/" original_guppy_config.yaml',
             ]

--- a/gen3-integration-tests/utils/gen3_admin_tasks.py
+++ b/gen3-integration-tests/utils/gen3_admin_tasks.py
@@ -734,7 +734,7 @@ def mutate_manifest_for_guppy_test(
         else:
             cmd_list = [
                 "kubectl -n "
-                + {test_env_namespace}
+                + test_env_namespace
                 + " get cm etl-mapping -o jsonpath='{.data.etlMapping\\.yaml}' > etlMapping.yaml",
                 'sed -i "s/"index":"[^"]*_subject_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep subject)"/" original_guppy_config.yaml',
                 'sed -i "s/"index":"[^"]*_file_alias"/"index":"\$(yq \'.mappings[].name\' etlMapping.yaml | grep file)"/" original_guppy_config.yaml',


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

### Bug Fixes
*  Fixed failing guppy test caused due to accidental type conversion from `str` to `set`
