### PR TITLE
Do not specify Gen3Auth endpoint

### DIFF
--- a/gen3-integration-tests/pages/gwas.py
+++ b/gen3-integration-tests/pages/gwas.py
@@ -385,7 +385,7 @@ class GWASPage(object):
         url = (
             f"{self.GWAS_WORKFLOW_API_ENDPOINT}?team_projects=/gwas_projects/{project}"
         )
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         response = auth.curl(path=url)
         return response.json()
 
@@ -395,7 +395,7 @@ class GWASPage(object):
         url = f"{self.GWAS_WORKFLOW_STATUS_API_ENDPOINT}/{job_id}?uid={uid_value}"
         while counter < 20:
             time.sleep(30)
-            auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+            auth = Gen3Auth(refresh_token=pytest.api_keys[user])
             response = auth.curl(path=url)
             wf_status = response.json()["phase"]
             if wf_status == "Succeeded":

--- a/gen3-integration-tests/services/audit.py
+++ b/gen3-integration-tests/services/audit.py
@@ -21,7 +21,7 @@ class Audit(object):
             "start={}".format(timestamp),
             "username={}".format(pytest.users[user]),
         ]
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = self.AUDIT_LOG_ENDPOINT + "/" + log_category
         url = url + "?" + "&".join(params)
         response = auth.curl(path=url)
@@ -35,7 +35,7 @@ class Audit(object):
         url = self.AUDIT_LOG_ENDPOINT + "/" + log_category
         url = url + "?" + "&".join(params)
         counter = 0
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
 
         while counter < 40:
             time.sleep(30)

--- a/gen3-integration-tests/services/dicom.py
+++ b/gen3-integration-tests/services/dicom.py
@@ -16,7 +16,7 @@ class Dicom(object):
             self.DICOM_STUDIES = "/dicom-server/studies"
 
     def submit_dicom_file(self, user="main_account", expected_status=200):
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         access_token = auth.get_access_token()
         url = self.BASE_URL + self.DICOM_INSTANCES
         with (TEST_DATA_PATH_OBJECT / "dicom/test_file.dcm").open("rb") as file:
@@ -34,7 +34,7 @@ class Dicom(object):
             return response.json()
 
     def get_studies(self, study_instance, user="main_account"):
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = self.DICOM_STUDIES + "/" + study_instance
         response = auth.curl(path=url)
         assert (
@@ -43,7 +43,7 @@ class Dicom(object):
         return response.json()
 
     def get_dicom_file(self, dicom_file_id, user="main_account", expected_status=200):
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = self.DICOM_INSTANCES + "/" + dicom_file_id
         response = auth.curl(path=url)
         assert (

--- a/gen3-integration-tests/services/drs.py
+++ b/gen3-integration-tests/services/drs.py
@@ -13,7 +13,7 @@ class Drs(object):
 
     def get_drs_object(self, file: dict, user="main_account"):
         """Get Drs object"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         try:
             id = file.get("did") or file.get("id")
         except Exception:
@@ -24,7 +24,7 @@ class Drs(object):
 
     def get_drs_signed_url(self, file, user="main_account"):
         """Get Drs signed url"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         try:
             id = file.get("did") or file.get("id")
         except Exception:
@@ -36,7 +36,7 @@ class Drs(object):
 
     def get_drs_signed_url_without_header(self, file, user="main_account"):
         """Get Drs signed url without header"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         try:
             id = file.get("did") or file.get("id")
         except Exception:

--- a/gen3-integration-tests/services/fence.py
+++ b/gen3-integration-tests/services/fence.py
@@ -51,7 +51,7 @@ class Fence(object):
         if len(params) > 0:
             url = url + "?" + "&".join(params)
         if user:
-            auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+            auth = Gen3Auth(refresh_token=pytest.api_keys[user])
             response = auth.curl(path=url)
         elif access_token:
             response = requests.get(
@@ -74,7 +74,7 @@ class Fence(object):
 
     def get_url_for_data_upload(self, file_name: str, user: str) -> dict:
         """Generate the url for uploading the data"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         headers = {
             "Content-Type": "application/json",
         }
@@ -87,7 +87,7 @@ class Fence(object):
         return response
 
     def get_url_for_data_upload_for_existing_file(self, guid: str, user: str) -> dict:
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         response = auth.curl(path=f"{self.DATA_UPLOAD_ENDPOINT}/{guid}")
         return response
 
@@ -110,7 +110,7 @@ class Fence(object):
 
     def delete_file(self, guid: str, user: str) -> int:
         """Deletes the file based on guid"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = f"{self.BASE_URL}{self.DATA_ENDPOINT}/{guid}"
         response = requests.delete(url=url, auth=auth)
         return response.status_code
@@ -128,7 +128,7 @@ class Fence(object):
                 },
             )
         else:
-            auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+            auth = Gen3Auth(refresh_token=pytest.api_keys[user])
             access_token = auth.get_access_token()
             user_info_response = auth.curl(path=f"{self.USER_ENDPOINT}")
         assert (
@@ -269,7 +269,7 @@ class Fence(object):
         return page.url
 
     def initialize_multipart_upload(self, file_name, user):
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         headers = {
             "Content-Type": "application/json",
         }
@@ -285,7 +285,7 @@ class Fence(object):
         return response.json()
 
     def get_url_for_multipart_upload(self, key, upload_id, part_number, user):
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         headers = {
             "Content-Type": "application/json",
         }
@@ -306,7 +306,7 @@ class Fence(object):
         headers = {
             "Content-Type": "application/json",
         }
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         response = requests.post(
             url=f"{self.BASE_URL}{self.MULTIPART_UPLOAD_COMPLETE_ENDPOINT}",
             data=json.dumps({"key": key, "uploadId": upload_id, "parts": parts}),
@@ -380,7 +380,7 @@ class Fence(object):
 
     def get_version(self, user="main_account"):
         """Get fence version"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         response = auth.curl(path=f"{self.VERSION_ENDPOINT}")
         assert (
             response.status_code == 200

--- a/gen3-integration-tests/services/gen3workflow.py
+++ b/gen3-integration-tests/services/gen3workflow.py
@@ -71,7 +71,7 @@ class Gen3Workflow:
         if not user:
             return None
 
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         return auth.get_access_token()
 
     def _get_s3_client(

--- a/gen3-integration-tests/services/graph.py
+++ b/gen3-integration-tests/services/graph.py
@@ -525,7 +525,7 @@ class GraphDataTools:
         min_monthly_release = "2023.04.0"
         monthly_release_cutoff = "2020"
 
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         response = auth.curl(path=self.GRAPHQL_VERSION_ENDPOINT)
         peregrine_version = response.json()["version"]
         url = f"{pytest.root_url}/api/search/coremetadata/"

--- a/gen3-integration-tests/services/guppy.py
+++ b/gen3-integration-tests/services/guppy.py
@@ -18,7 +18,7 @@ class Guppy(object):
         user - pick one from conftest.py - main_account / indexing_account / dummy_one /
             smarty_two / user0_account
         """
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = self.BASE_ENDPOINT + "/_status"
         response = auth.curl(path=url)
         logger.info("Guppy status code : " + str(response.status_code))
@@ -56,7 +56,7 @@ class Guppy(object):
         )
         queryToSubmit = "".join(queryFile.split("\n"))
         logger.info(queryToSubmit)
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = self.BASE_ENDPOINT + endpoint
         headers = {
             "Content-Type": "application/json",

--- a/gen3-integration-tests/services/indexd.py
+++ b/gen3-integration-tests/services/indexd.py
@@ -54,7 +54,7 @@ class Indexd(object):
     ):
         """Update indexd record"""
         if not access_token:
-            auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+            auth = Gen3Auth(refresh_token=pytest.api_keys[user])
             access_token = auth.get_access_token()
         headers = {
             "Authorization": f"bearer {access_token}",
@@ -73,7 +73,7 @@ class Indexd(object):
     ):
         """Delete indexd record if upload is not happening through gen3-sdk"""
         if not access_token:
-            auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+            auth = Gen3Auth(refresh_token=pytest.api_keys[user])
             access_token = auth.get_access_token()
         headers = {
             "Authorization": f"bearer {access_token}",
@@ -127,7 +127,7 @@ class Indexd(object):
 
     def clear_previous_upload_files(self, user="main_account"):
         """Delete indexd record if upload is not happening through gen3-sdk"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = f"/index/index/?acl=null&authz=null&uploader={pytest.users[user]}"
         response = auth.curl(path=url)
         logger.info(response.json())

--- a/gen3-integration-tests/services/requestor.py
+++ b/gen3-integration-tests/services/requestor.py
@@ -115,7 +115,7 @@ class Requestor(object):
 
     def get_request_status(self, request_id: str, user: str = "main_account"):
         """Gets the request_status for the user's request_id in requestor"""
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         status_res = auth.curl(path=request_id)
         status_data_json = status_res.json()
         req_status = status_data_json["status"]
@@ -125,7 +125,7 @@ class Requestor(object):
     def request_signed(self, request_id: str, user: str = "main_account"):
         """Updates the request to SIGNED status"""
         logger.info(f"Updating the {request_id} to SIGNED status ...")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         access_token = auth.get_access_token()
         headers = {
             "Accept": "application/json",
@@ -141,7 +141,7 @@ class Requestor(object):
     def request_approved(self, request_id: str, user: str = "main_account"):
         """Updates the request to APPROVED status"""
         logger.info(f"Updating the {request_id} to APPROVED status ...")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         access_token = auth.get_access_token()
         headers = {
             "Accept": "application/json",
@@ -157,7 +157,7 @@ class Requestor(object):
     def request_delete(self, request_id: str, user: str = "main_account"):
         """Deletes the request fro requestor"""
         logger.info(f"Deleting the {request_id} ...")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=self.BASE_URL)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         access_token = auth.get_access_token()
         headers = {
             "Accept": "application/json",

--- a/gen3-integration-tests/services/userdatalibrary.py
+++ b/gen3-integration-tests/services/userdatalibrary.py
@@ -13,7 +13,7 @@ class UserDataLibrary(object):
     def create_list(self, user, data, expected_status=201):
         """helper function to create list in data library"""
         logger.info("Creating Data Library List")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         url = f"{pytest.root_url}/{self.LISTS_ENDPOINT}"
         headers = {
             "Content-Type": "application/json",
@@ -36,7 +36,7 @@ class UserDataLibrary(object):
         reads all lists if list_id is not passed
         """
         logger.info("Reading Data Library List")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         if list_id:
             url = f"{self.LISTS_ENDPOINT}/{list_id}"
         else:
@@ -52,7 +52,7 @@ class UserDataLibrary(object):
     def update_list(self, user, list_id, data, expected_status=200):
         """helper function to update list in data library"""
         logger.info("Updating Data Library List")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         headers = {
             "Authorization": f"bearer {auth.get_access_token()}",
             "Content-Type": "application/json",
@@ -74,7 +74,7 @@ class UserDataLibrary(object):
         deletes all lists if list_id is None
         """
         logger.info("Deleting Data Library List")
-        auth = Gen3Auth(refresh_token=pytest.api_keys[user], endpoint=pytest.root_url)
+        auth = Gen3Auth(refresh_token=pytest.api_keys[user])
         if list_id:
             url = f"{pytest.root_url}/{self.LISTS_ENDPOINT}/{list_id}"
         else:

--- a/gen3-integration-tests/tests/test_env_sanity.py
+++ b/gen3-integration-tests/tests/test_env_sanity.py
@@ -44,10 +44,7 @@ class TestEnvSanity:
                     logger.info(
                         f"Service {service_name} found, checking service version"
                     )
-                    auth = Gen3Auth(
-                        refresh_token=pytest.api_keys["main_account"],
-                        endpoint=pytest.root_url,
-                    )
+                    auth = Gen3Auth(refresh_token=pytest.api_keys["main_account"])
                     url = service_endpoints[service_name]
                     response = auth.curl(path=url)
                     assert (

--- a/gen3-integration-tests/tests/test_user_token.py
+++ b/gen3-integration-tests/tests/test_user_token.py
@@ -112,9 +112,7 @@ class TestUserToken:
         api_key_res, access_token = self.fence.create_api_key(scope=scope, page=page)
 
         # Generate access_token using the api_key
-        auth = Gen3Auth(
-            refresh_token=api_key_res.json(), endpoint=f"{pytest.root_url}/user"
-        )
+        auth = Gen3Auth(refresh_token=api_key_res.json())
         auth.get_access_token()
 
         # Delete the api key and logout
@@ -132,7 +130,7 @@ class TestUserToken:
         gen3_sdk_error_msg = "string indices must be integers"
 
         # Refresh access token using invalid api_key
-        auth = Gen3Auth(refresh_token="invalid", endpoint=f"{pytest.root_url}/user")
+        auth = Gen3Auth(refresh_token="invalid")
         try:
             auth.refresh_access_token()
         except Exception as e:
@@ -154,7 +152,7 @@ class TestUserToken:
 
         # Refresh access token using no api_key
         try:
-            auth = Gen3Auth(refresh_token=None, endpoint=f"{pytest.root_url}/user")
+            auth = Gen3Auth(refresh_token=None)
             auth.refresh_access_token()
         except Exception as e:
             expection_content = str(e)


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

Relates to https://github.com/uc-cdis/gen3sdk-python/pull/296

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Do not specify the endpoint when initializing Gen3Auth with an API key, only when initializing it with OIDC client credentials

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
