### PR TITLE
Get more service logs in case of TES error

### DIFF
--- a/gen3-integration-tests/services/gen3workflow.py
+++ b/gen3-integration-tests/services/gen3workflow.py
@@ -70,8 +70,9 @@ def _print_tes_apps_logs(describe_task_pods=False):
             "logs",
             "-l",
             f"app={app}",
+            "--all-containers",
             "--tail",
-            "100",
+            "-1",  # all the logs
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode == 0:

--- a/gen3-integration-tests/services/gen3workflow.py
+++ b/gen3-integration-tests/services/gen3workflow.py
@@ -72,7 +72,7 @@ def _print_tes_apps_logs(describe_task_pods=False):
             f"app={app}",
             "--all-containers",
             "--tail",
-            "-1",  # all the logs
+            "200",
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode == 0:


### PR DESCRIPTION
This is useful for debugging errors in the Kind cluster version of the integration tests workflow.
