### PR TITLE
Fix file_equals and wait_upload_file_updated_from_indexd_listener

### DIFF
--- a/gen3-integration-tests/services/fence.py
+++ b/gen3-integration-tests/services/fence.py
@@ -337,6 +337,7 @@ class Fence(object):
 
     @retry(times=10, delay=30, exceptions=(AssertionError))
     def wait_upload_file_updated_from_indexd_listener(self, indexd, file_node):
+        logger.info(f"Waiting for uploaded file '{file_node.did}' to be updated")
         response = indexd.get_record(file_node.did)
         indexd.file_equals(res=response, file_record=file_node)
         return response

--- a/gen3-integration-tests/services/indexd.py
+++ b/gen3-integration-tests/services/indexd.py
@@ -97,29 +97,29 @@ class Indexd(object):
                 logger.exception(msg=f"Failed to delete record with guid {guid} : {e}")
 
     def file_equals(self, res: dict, file_record: dict) -> None:
-        logger.info(f"Response data : {res}")
+        logger.info(f"Response data: {res}")
         logger.info(f"File Node: {file_record.props}")
         errors = []
-        if res["hashes"]["md5"] != file_record.props["md5sum"]:
+        if res.get("hashes", {}).get("md5") != file_record.props.get("md5sum"):
             errors.append(
-                f"md5 value mismatch: '{res['hashes']['md5']}' != '{file_record.props['md5sum']}'"
+                f"md5 value mismatch: '{res.get("hashes", {}).get("md5")}' != '{file_record.props.get("md5sum")}'"
             )
-        if res["size"] != file_record.props["file_size"]:
+        if res.get("size") != file_record.props.get("file_size"):
             errors.append(
-                f"file_size value mismatch: '{res['size']}' != '{file_record.props['file_size']}'"
+                f"file_size value mismatch: '{res.get("size")}' != '{file_record.props.get('file_size')}'"
             )
         if "urls" not in res.keys():
             errors.append(f"urls keyword missing in {res.keys()}")
         if "urls" in file_record.props.keys():
-            if file_record.props["urls"] not in res["urls"]:
+            if file_record.props.get("urls") not in res.get("urls", []):
                 errors.append(
-                    f"urls value mismatch: {file_record.props['urls']} not in {res['urls']}"
+                    f"urls value mismatch: {file_record.props.get('urls')} not in {res.get('urls')}"
                 )
         if "authz" in file_record.props.keys():
-            for authz_val in file_record.props["authz"]:
-                if authz_val not in res["authz"]:
+            for authz_val in file_record.props.get("authz", []):
+                if authz_val not in res.get("authz", []):
                     errors.append(
-                        f"{authz_val} not found in authz list: {res['authz']}"
+                        f"{authz_val} not found in authz list: {res.get('authz')}"
                     )
         if errors:
             logger.error(f"indexd.file_equals(): files do not match: {errors}")

--- a/gen3-integration-tests/services/indexd.py
+++ b/gen3-integration-tests/services/indexd.py
@@ -123,7 +123,7 @@ class Indexd(object):
                     )
         if errors:
             logger.error(f"indexd.file_equals(): files do not match: {errors}")
-        return len(errors) == 0, errors
+        assert len(errors) == 0, errors
 
     def clear_previous_upload_files(self, user="main_account"):
         """Delete indexd record if upload is not happening through gen3-sdk"""

--- a/gen3-integration-tests/tests/test_data_upload.py
+++ b/gen3-integration-tests/tests/test_data_upload.py
@@ -384,6 +384,7 @@ class TestDataUpload:
             file_name, "main_account"
         ).json()
         file_guid = fence_upload_res["guid"]
+        logger.info(f"First file upload; GUID: {file_guid}")
         self.created_guids.append(file_guid)
         presigned_url = fence_upload_res["url"]
 
@@ -417,11 +418,15 @@ class TestDataUpload:
             file_name, "main_account"
         ).json()
         file_guid = fence_upload_res["guid"]
+        logger.info(f"Second file upload; GUID: {file_guid}")
         self.created_guids.append(file_guid)
         presigned_url = fence_upload_res["url"]
 
         # Upload the file to the S3 bucket using the presigned URL
         self.fence.upload_file_using_presigned_url(presigned_url, file_path, file_size)
+        file_record = FileRecord(
+            did=file_guid, props={"md5sum": file_md5, "file_size": file_size}
+        )
 
         # wait for the indexd listener to add size, hashes and URL to the record
         self.fence.wait_upload_file_updated_from_indexd_listener(

--- a/gen3-integration-tests/tests/test_data_upload.py
+++ b/gen3-integration-tests/tests/test_data_upload.py
@@ -352,7 +352,7 @@ class TestDataUpload:
         except Exception as e:
             assert (
                 "400" in f"{e}"
-            ), f"Linking metadata to file without hash and size should not be possible.\n{metadata_response}"
+            ), f"Linking metadata to file without hash and size should not be possible"
 
         # no download after delete
         self.fence.create_signed_url(


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

When `res["hashes"]` is `{}`, `res["hashes"]["md5"]` raises a KeyError.
[This function](https://github.com/uc-cdis/gen3-code-vigil/blob/6875b450c5183009accc3e8c946f62275465ff7b/gen3-integration-tests/services/fence.py#L338-L342) retries on `AssertionError`, not `KeyError`, so tests fail.

Also update `file_equals()` to actually raise an `AssertionError` in case of mismatch.

### New Features

### Breaking Changes

### Bug Fixes
- Fix `file_equals` and `wait_upload_file_updated_from_indexd_listener` to actually check for errors and retry if needed

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
