### PR TITLE
get_navigation_url failing CI when portal is not enabled

### DIFF
--- a/gen3-integration-tests/utils/gen3_admin_tasks.py
+++ b/gen3-integration-tests/utils/gen3_admin_tasks.py
@@ -52,6 +52,9 @@ def get_portal_config(json_file_name=None):
 def get_navigation_url():
     naviagtion_urls = {}
     res = get_portal_config(json_file_name="navigation")
+    if not res:
+        logger.info("Portal config not found. Skipping navigation url fetch.")
+        return naviagtion_urls
     # This key is part of gitops for portal
     if res.get("components"):
         for item in res["components"]["navigation"]["items"]:

--- a/gen3-integration-tests/utils/gen3_admin_tasks.py
+++ b/gen3-integration-tests/utils/gen3_admin_tasks.py
@@ -53,7 +53,7 @@ def get_navigation_url():
     naviagtion_urls = {}
     res = get_portal_config(json_file_name="navigation")
     if not res:
-        logger.info("Portal config not found. Skipping navigation url fetch.")
+        logger.info("Portal/FeFF config not found. Skipping navigation url fetch.")
         return naviagtion_urls
     # This key is part of gitops for portal
     if res.get("components"):


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
* Add null check for portal_config to fix CI failure when portal is disabled
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
